### PR TITLE
Assert macros: fixed handling of commas in arguments

### DIFF
--- a/include/fwk/format.h
+++ b/include/fwk/format.h
@@ -103,7 +103,7 @@ namespace detail {
 	}
 
 	void formatSpan(TextFormatter &out, const char *data, int size, int obj_size, TFFunc);
-	string autoPrintFormat(const char *args);
+	string autoPrintFormat(const array<const char *, 8> &);
 
 	template <class... T> struct TFFuncs {
 		static constexpr TFFunc funcs[] = {getTFFunc<T>()...};
@@ -337,7 +337,8 @@ template <c_formattible... T> string format(const char *str, T &&...);
 template <c_formattible... T> void print(const char *str, T &&...);
 template <c_formattible... T> void printPlain(const char *str, T &&...);
 
-#define FWK_DUMP(...) fwk::print(fwk::detail::autoPrintFormat(#__VA_ARGS__).c_str(), __VA_ARGS__)
+#define FWK_DUMP(...)                                                                              \
+	fwk::print(fwk::detail::autoPrintFormat({FWK_STRINGIZE_MANY(__VA_ARGS__)}).c_str(), __VA_ARGS__)
 }
 
 #endif

--- a/include/fwk/sys/assert_impl.h
+++ b/include/fwk/sys/assert_impl.h
@@ -23,7 +23,7 @@ namespace detail {
 	struct AssertInfo {
 		const char *file;
 		const char *message;
-		const char *arg_names;
+		array<const char *, 8> arg_names;
 		const detail::TFFunc *funcs;
 		int line;
 		int arg_count;
@@ -32,12 +32,12 @@ namespace detail {
 	};
 
 	using CallFunc = void (*)(const AssertInfo *, ...);
-	template <ConstString file, int line, ConstString message, ConstString arg_names, class Func,
-			  class... T>
+	template <ConstString file, int line, ConstString message, ConstString... arg_names, class Func,
+			  c_formattible... T>
 	inline auto assertCall(const Func &func, const T &...args) {
-		static_assert((is_formattible<T> && ...));
+		static_assert(sizeof...(arg_names) <= 8);
 		using Funcs = decltype(detail::formatFuncs(args...));
-		static constexpr AssertInfo info{file.string,  message.string, arg_names.string,
+		static constexpr AssertInfo info{file.string,  message.string, {arg_names.string...},
 										 Funcs::funcs, line,		   Funcs::count};
 		return func(&info, detail::getTFValue(args)...);
 	}
@@ -50,15 +50,15 @@ namespace detail {
 // Message format: text + list of named params
 #define _ASSERT_WITH_PARAMS(func, message, ...)                                                    \
 	({                                                                                             \
-		fwk::detail::assertCall<__FILE__, __LINE__, message, FWK_STRINGIZE(__VA_ARGS__)>(          \
+		fwk::detail::assertCall<__FILE__, __LINE__, message, FWK_STRINGIZE_MANY(__VA_ARGS__)>(     \
 			fwk::detail::func __VA_OPT__(, ) __VA_ARGS__);                                         \
 	})
 
 // Message format: format text + its arguments
 #define _ASSERT_FORMATTED(func, fmt, ...)                                                          \
 	({                                                                                             \
-		fwk::detail::assertCall<__FILE__, __LINE__, fmt, "">(fwk::detail::func __VA_OPT__(, )      \
-																 __VA_ARGS__);                     \
+		fwk::detail::assertCall<__FILE__, __LINE__, fmt>(fwk::detail::func __VA_OPT__(, )          \
+															 __VA_ARGS__);                         \
 	})
 
 }

--- a/include/fwk/sys_base.h
+++ b/include/fwk/sys_base.h
@@ -105,6 +105,20 @@
 #define FWK_JOIN(a, b) FWK_JOIN_(a, b)
 #define FWK_JOIN_(a, b) a##b
 
+#define FWK_NUM_ARGS_(_1, _2, _3, _4, _5, _6, _7, _8, N, ...) N
+#define FWK_NUM_ARGS(args...) FWK_NUM_ARGS_(args..., 8, 7, 6, 5, 4, 3, 2, 1)
+
+#define FWK_STRINGIZE_1(x) #x
+#define FWK_STRINGIZE_2(x, x2) #x, #x2
+#define FWK_STRINGIZE_3(x, x2, x3) #x, #x2, #x3
+#define FWK_STRINGIZE_4(x, x2, x3, x4) #x, #x2, #x3, #x4
+#define FWK_STRINGIZE_5(x, x2, x3, x4, x5) #x, #x2, #x3, #x4, #x5
+#define FWK_STRINGIZE_6(x, x2, x3, x4, x5, x6) #x, #x2, #x3, #x4, #x5, #x6
+#define FWK_STRINGIZE_7(x, x2, x3, x4, x5, x6, x7) #x, #x2, #x3, #x4, #x5, #x6
+#define FWK_STRINGIZE_8(x, x2, x3, x4, x5, x6, x7, x8) #x, #x2, #x3, #x4, #x5, #x6, #x7, #x8
+
+#define FWK_STRINGIZE_MANY(args...) FWK_JOIN(FWK_STRINGIZE_, FWK_NUM_ARGS(args))(args)
+
 namespace fwk {
 
 using std::string;

--- a/src/format.cpp
+++ b/src/format.cpp
@@ -12,10 +12,8 @@
 namespace fwk {
 
 namespace detail {
-	string autoPrintFormat(const char *args) {
+	string autoPrintFormat(const array<const char *, 8> &args) {
 		TextFormatter out;
-		// TODO: properly handle parenthesis, etc.
-		Tokenizer tok(args, ',');
 
 		auto append_elem = [&](Str elem) {
 			for(auto c : elem)
@@ -26,15 +24,16 @@ namespace detail {
 		};
 
 		bool back_trim = false;
-		while(!tok.finished()) {
-			auto elem = tok.next();
+		for(auto &arg : args) {
+			if(!arg)
+				break;
+			Str elem = arg;
 
 			while(elem && isspace(elem[0]))
 				elem = elem.substr(1);
 			while(elem && isspace(elem[elem.size() - 1]))
 				elem = elem.substr(0, elem.size() - 1);
 
-			// TODO: handle % in elems
 			DASSERT(elem);
 			back_trim = true;
 			if(elem[0] == '"' && elem[elem.size() - 1] == '"') {

--- a/src/sys/assert_impl.cpp
+++ b/src/sys/assert_impl.cpp
@@ -13,9 +13,7 @@ namespace fwk {
 namespace detail {
 
 	string AssertInfo::preFormat(TextFormatter &out, const char *prefix) const {
-		string temp;
-
-		if(strlen(arg_names) > 0) {
+		if(anyOf(arg_names)) {
 			out("%%\n", prefix, message);
 			return detail::autoPrintFormat(arg_names);
 		} else {


### PR DESCRIPTION
Also added FWK_STRINGIZE_MANY