### PR TITLE
Vulkan descriptors: Added option to allow update after bind

### DIFF
--- a/include/fwk/vulkan/vulkan_descriptor_manager.h
+++ b/include/fwk/vulkan/vulkan_descriptor_manager.h
@@ -16,7 +16,7 @@ namespace fwk {
 
 class VulkanDescriptorManager {
   public:
-	VulkanDescriptorManager(VkDevice);
+	VulkanDescriptorManager(VkDevice, bool update_after_bind);
 	FWK_IMMOVABLE_CLASS(VulkanDescriptorManager);
 
 	VDSLId getEmptyLayout() const { return m_empty_dsl_id; }
@@ -66,11 +66,13 @@ class VulkanDescriptorManager {
 	vector<VDescriptorBindingInfo> m_declarations;
 	vector<DSL> m_dsls;
 	vector<VkDescriptorPool> m_deferred_releases[VulkanLimits::num_swap_frames];
+	vector<VkDescriptorBindingFlagsEXT> m_binding_flags;
 	HashMap<HashedDSL, VDSLId> m_hash_map;
 	VDSLId m_empty_dsl_id = VDSLId(0);
 
 	uint m_swap_frame_index = 0;
 	bool m_frame_running = false;
+	bool m_update_after_bind = false;
 };
 
 }

--- a/include/fwk/vulkan/vulkan_pipeline.h
+++ b/include/fwk/vulkan/vulkan_pipeline.h
@@ -275,7 +275,7 @@ struct VDescriptorBindingInfo {
 	u64 value = 0;
 };
 
-// DescriptorSets can only be used during the same frame during which they were acquired
+// DescriptorSets can only be used during the same frame in which they were acquired
 struct VDescriptorSet {
 	VDescriptorSet(VulkanDevice &device, VkDescriptorSet handle, u64 bindings_map)
 		: device(&device), handle(handle), bindings_map(bindings_map) {}

--- a/include/fwk/vulkan_base.h
+++ b/include/fwk/vulkan_base.h
@@ -121,7 +121,8 @@ DEFINE_ENUM(VTexFilter, nearest, linear);
 DEFINE_ENUM(VTexAddress, repeat, mirror_repeat, clamp_to_edge, clamp_to_border,
 			mirror_clamp_to_edge);
 
-DEFINE_ENUM(VDeviceFeature, memory_budget, subgroup_size_control, shader_clock, ray_tracing);
+DEFINE_ENUM(VDeviceFeature, memory_budget, subgroup_size_control, shader_clock, ray_tracing,
+			descriptor_update_after_bind);
 using VDeviceFeatures = EnumFlags<VDeviceFeature>;
 
 DEFINE_ENUM(VMemoryBlockType, slab, unmanaged, frame, invalid);
@@ -346,6 +347,8 @@ struct VDeviceSetup {
 	vector<VQueueSetup> queues;
 	VMemoryManagerSetup memory;
 	Dynamic<VkPhysicalDeviceFeatures> features;
+
+	bool allow_descriptor_update_after_bind = false;
 };
 
 DEFINE_ENUM(VColorSyncStd, clear, clear_present, present, draw);

--- a/src/vulkan/vulkan_device.cpp
+++ b/src/vulkan/vulkan_device.cpp
@@ -244,6 +244,13 @@ Ex<void> VulkanDevice::initialize(const VDeviceSetup &setup) {
 		acc_features.accelerationStructure = VK_TRUE;
 	}
 
+	if(setup.allow_descriptor_update_after_bind) {
+		v12_features.descriptorBindingStorageBufferUpdateAfterBind = VK_TRUE;
+		v12_features.descriptorBindingUniformBufferUpdateAfterBind = VK_TRUE;
+		v12_features.descriptorBindingSampledImageUpdateAfterBind = VK_TRUE;
+		m_features |= VDeviceFeature::descriptor_update_after_bind;
+	}
+
 	vector<const char *> c_exts = transform(exts, [](auto &str) { return str.c_str(); });
 	VkDeviceCreateInfo ci{VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO};
 	ci.pQueueCreateInfos = queue_cis.data();
@@ -273,7 +280,7 @@ Ex<void> VulkanDevice::initialize(const VDeviceSetup &setup) {
 	FWK_VK_EXPECT_CALL(vkCreatePipelineCache, m_handle, &pip_ci, nullptr,
 					   &m_objects->pipeline_cache);
 
-	m_descriptors.emplace(m_handle);
+	m_descriptors.emplace(m_handle, !!(m_features & VDeviceFeature::descriptor_update_after_bind));
 	auto mem_setup = setup.memory;
 	mem_setup.enable_device_address |= !!(m_features & VDeviceFeature::ray_tracing);
 	m_memory.emplace(m_handle, m_instance_ref->info(m_phys_id), m_features, mem_setup);

--- a/src/vulkan/vulkan_internal.cpp
+++ b/src/vulkan/vulkan_internal.cpp
@@ -74,7 +74,7 @@ VkDescriptorPool createVkDescriptorPool(VkDevice device, EnumMap<VDescriptorType
 	ci.poolSizeCount = num_sizes;
 	ci.pPoolSizes = sizes.data();
 	ci.maxSets = set_count;
-	ci.flags = 0; //TODO
+	ci.flags = flags.bits;
 	VkDescriptorPool handle;
 	FWK_VK_CALL(vkCreateDescriptorPool, device, &ci, nullptr, &handle);
 	return handle;


### PR DESCRIPTION
Descriptors were actually used that way in different apps, but the necessary flags weren't enabled.
This caused visual glitches in FreeFT on Nvidia GPUs.