### PR TITLE
Cleanup in Vulkan format

### DIFF
--- a/include/fwk/gfx/image.h
+++ b/include/fwk/gfx/image.h
@@ -18,14 +18,14 @@ using ImageRescaleOpts = EnumFlags<ImageRescaleOpt>;
 
 class Image {
   public:
-	explicit Image(int2 size, VFormat = VFormat::rgba8_unorm);
-	Image(Image, VFormat new_format);
-	Image(int2 size, NoInitTag, VFormat = VFormat::rgba8_unorm);
-	Image(int2 size, IColor fill, VFormat = VFormat::rgba8_unorm);
-	Image(PodVector<u8>, int2 size, VFormat);
+	explicit Image(int2 size, VColorFormat = VColorFormat::rgba8_unorm);
+	Image(Image, VColorFormat new_format);
+	Image(int2 size, NoInitTag, VColorFormat = VColorFormat::rgba8_unorm);
+	Image(int2 size, IColor fill, VColorFormat = VColorFormat::rgba8_unorm);
+	Image(PodVector<u8>, int2 size, VColorFormat);
 
-	template <c_pixel T> Image(PodVector<T> data, int2 size, VFormat format);
-	template <c_pixel T> Image(int2 size, T fill, VFormat format);
+	template <c_pixel T> Image(PodVector<T> data, int2 size, VColorFormat format);
+	template <c_pixel T> Image(int2 size, T fill, VColorFormat format);
 	Image();
 	~Image();
 
@@ -54,9 +54,9 @@ class Image {
 	void resize(int2, Maybe<IColor> fill = IColor(ColorId::black));
 	Image rescale(int2 new_size, ImageRescaleOpts opts = none) const;
 
-	void setFormat(VFormat new_format);
+	void setFormat(VColorFormat new_format);
 
-	static Image compressBC(const Image &, VFormat);
+	static Image compressBC(const Image &, VColorFormat);
 
 	static int maxMipmapLevels(int max_dimension) { return int(log2(max_dimension)) + 1; }
 	static int maxMipmapLevels(int2 size) { return maxMipmapLevels(max(size.x, size.y)); }
@@ -70,7 +70,7 @@ class Image {
 	int height() const { return m_size.y; }
 	int2 size() const { return m_size; }
 
-	VFormat format() const { return m_format; }
+	VColorFormat format() const { return m_format; }
 	bool empty() const { return m_size.x == 0 || m_size.y == 0; }
 
 	template <c_pixel T> Span<T> row(int y);
@@ -82,20 +82,20 @@ class Image {
   private:
 	PodVector<u8> m_data;
 	int2 m_size;
-	VFormat m_format;
+	VColorFormat m_format;
 };
 
 // -------------------------------------------------------------------------------------------
 // ---  Inlined code -------------------------------------------------------------------------
 
 template <c_pixel T>
-Image::Image(PodVector<T> data, int2 size, VFormat format)
+Image::Image(PodVector<T> data, int2 size, VColorFormat format)
 	: m_data(std::move(data.template reinterpret<u8>())), m_size(size), m_format(format) {
 	DASSERT(sizeof(T) == unitByteSize(format));
 	DASSERT(m_data.size() * sizeof(T) >= imageByteSize(format, m_size));
 }
 
-template <c_pixel T> Image::Image(int2 size, T value, VFormat format) : Image(size, format) {
+template <c_pixel T> Image::Image(int2 size, T value, VColorFormat format) : Image(size, format) {
 	fill(value);
 }
 

--- a/include/fwk/gfx/image_view.h
+++ b/include/fwk/gfx/image_view.h
@@ -47,7 +47,7 @@ template <class T> struct PixelInfo {};
 
 #define PIXEL_TYPE(Type, default_format_)                                                          \
 	template <> struct PixelInfo<Type> {                                                           \
-		static constexpr VFormat default_format = VFormat::default_format_;                        \
+		static constexpr VColorFormat default_format = VColorFormat::default_format_;              \
 	};
 
 PIXEL_TYPE(IColor, rgba8_unorm)
@@ -125,7 +125,7 @@ template <c_pixel T> class ImageIter {
 template <c_pixel T> class ImageView {
   public:
 	ImageView(const ImageView<RemoveConst<T>> &rhs);
-	ImageView(T *pixels, int2 size, int stride, VFormat format);
+	ImageView(T *pixels, int2 size, int stride, VColorFormat format);
 	ImageView();
 	~ImageView() = default;
 
@@ -136,7 +136,7 @@ template <c_pixel T> class ImageView {
 
 	bool inRange(int x, int y) const;
 
-	VFormat format() const { return m_format; }
+	VColorFormat format() const { return m_format; }
 	bool empty() const { return m_size.x == 0 || m_size.y == 0; }
 
 	Span<T> row(int y);
@@ -161,7 +161,7 @@ template <c_pixel T> class ImageView {
 	T *m_pixels;
 	int2 m_size;
 	int m_stride;
-	VFormat m_format;
+	VColorFormat m_format;
 };
 
 // -------------------------------------------------------------------------------------------
@@ -172,14 +172,14 @@ ImageView<T>::ImageView(const ImageView<RemoveConst<T>> &rhs)
 	: m_pixels(rhs.m_pixels), m_size(rhs.m_size), m_stride(rhs.m_stride), m_format(rhs.m_format) {}
 
 template <c_pixel T>
-ImageView<T>::ImageView(T *pixels, int2 size, int stride, VFormat format)
+ImageView<T>::ImageView(T *pixels, int2 size, int stride, VColorFormat format)
 	: m_pixels(pixels), m_size(size), m_stride(stride), m_format(format) {
 	DASSERT(stride > 0 && size.x >= 0 && size.y >= 0);
 	DASSERT(unitByteSize(format) == sizeof(T));
 }
 
 template <c_pixel T>
-ImageView<T>::ImageView() : m_pixels(nullptr), m_stride(1), m_format(VFormat::rgba8_unorm) {}
+ImageView<T>::ImageView() : m_pixels(nullptr), m_stride(1), m_format(VColorFormat::rgba8_unorm) {}
 
 template <c_pixel T> inline bool ImageView<T>::inRange(int x, int y) const {
 	return x >= 0 && y >= 0 && x < m_size.x && y < m_size.y;

--- a/include/fwk/vulkan/vulkan_instance.h
+++ b/include/fwk/vulkan/vulkan_instance.h
@@ -91,7 +91,7 @@ class VulkanInstance {
 											 vector<VQueueSetup> * = nullptr) const;
 	Ex<VDeviceRef> createDevice(VPhysicalDeviceId, const VDeviceSetup &);
 
-	VFormatSupport formatSupport(VPhysicalDeviceId, VFormat) const;
+	VFormatSupport formatSupport(VPhysicalDeviceId, VColorFormat) const;
 	VFormatSupport formatSupport(VPhysicalDeviceId, VDepthStencilFormat) const;
 
 	VkInstance handle() { return m_handle; }

--- a/include/fwk/vulkan/vulkan_internal.h
+++ b/include/fwk/vulkan/vulkan_internal.h
@@ -70,8 +70,8 @@ inline auto fromVkDepthStencilFormat(VkFormat format) {
 			   Maybe<VDepthStencilFormat>();
 }
 
-VkFormat toVk(VFormat);
-Maybe<VFormat> fromVk(VkFormat);
+VkFormat toVk(VColorFormat);
+Maybe<VColorFormat> fromVkColorFormat(VkFormat);
 
 inline VkFormatFeatureFlags toVk(VFormatFeatures features) {
 	u32 low_bits = features.bits & 0x1fffu, high_bits = features.bits >> 13;

--- a/include/fwk/vulkan/vulkan_pipeline.h
+++ b/include/fwk/vulkan/vulkan_pipeline.h
@@ -16,25 +16,25 @@ template <class T> struct VAutoVulkanFormat {};
 	template <> struct VAutoVulkanFormat<type_> {                                                  \
 		static constexpr auto format = format_;                                                    \
 	};
-AUTO_FORMAT(float, VK_FORMAT_R32_SFLOAT)
-AUTO_FORMAT(float2, VK_FORMAT_R32G32_SFLOAT)
-AUTO_FORMAT(float3, VK_FORMAT_R32G32B32_SFLOAT)
-AUTO_FORMAT(float4, VK_FORMAT_R32G32B32A32_SFLOAT)
-AUTO_FORMAT(int, VK_FORMAT_R32_SINT)
-AUTO_FORMAT(int2, VK_FORMAT_R32G32_SINT)
-AUTO_FORMAT(int3, VK_FORMAT_R32G32B32_SINT)
-AUTO_FORMAT(int4, VK_FORMAT_R32G32B32A32_SINT)
-AUTO_FORMAT(u32, VK_FORMAT_R32_UINT)
-AUTO_FORMAT(IColor, VK_FORMAT_R8G8B8A8_UNORM)
+AUTO_FORMAT(float, VColorFormat::r32_sfloat)
+AUTO_FORMAT(float2, VColorFormat::rg32_sfloat)
+AUTO_FORMAT(float3, VColorFormat::rgb32_sfloat)
+AUTO_FORMAT(float4, VColorFormat::rgba32_sfloat)
+AUTO_FORMAT(int, VColorFormat::r32_sint)
+AUTO_FORMAT(int2, VColorFormat::rg32_sint)
+AUTO_FORMAT(int3, VColorFormat::rgb32_sint)
+AUTO_FORMAT(int4, VColorFormat::rgba32_sint)
+AUTO_FORMAT(u32, VColorFormat::r32_uint)
+AUTO_FORMAT(IColor, VColorFormat::rgba8_unorm)
 #undef AUTO_FORMAT
 
 struct VVertexAttrib {
 	VVertexAttrib(uint location_index, uint binding_index, uint offset = 0,
-				  VkFormat format = VK_FORMAT_R32_SFLOAT)
+				  VColorFormat format = VColorFormat::r32_sfloat)
 		: format(format), offset(offset), location_index(location_index),
 		  binding_index(binding_index) {}
 
-	VkFormat format;
+	VColorFormat format;
 	u16 offset;
 	u8 location_index;
 	u8 binding_index;

--- a/include/fwk/vulkan/vulkan_swap_chain.h
+++ b/include/fwk/vulkan/vulkan_swap_chain.h
@@ -23,7 +23,7 @@ class VulkanSwapChain : public VulkanObjectBase<VulkanSwapChain> {
 	static VSurfaceInfo surfaceInfo(VulkanDevice &, VWindowRef);
 	static Ex<PVSwapChain> create(VulkanDevice &, VWindowRef, const VSwapChainSetup &);
 
-	VkFormat format() const { return m_format; }
+	VColorFormat format() const { return m_format; }
 	int2 size() const { return m_size; }
 	int numImages() const { return m_image_views.size(); }
 
@@ -57,7 +57,7 @@ class VulkanSwapChain : public VulkanObjectBase<VulkanSwapChain> {
 	vector<PVImageView> m_image_views;
 	array<VkSemaphore, 4> m_semaphores = {};
 	VkQueue m_present_queue;
-	VkFormat m_format;
+	VColorFormat m_format;
 	int2 m_size;
 	uint m_image_index = 0;
 	uint m_semaphore_index = 0;

--- a/include/fwk/vulkan_base.h
+++ b/include/fwk/vulkan_base.h
@@ -166,7 +166,7 @@ constexpr int unitSize(VBaseFormat format) { return isBlock(format) ? 4 : 1; }
 //    srgb: unorm with RGB additionally using sRGB nonlinear encoding
 DEFINE_ENUM(VNumericFormat, unorm, snorm, uint, sint, ufloat, sfloat, srgb);
 
-DEFINE_ENUM(VFormat,
+DEFINE_ENUM(VColorFormat,
 			//  8-bit R8
 			r8_unorm, r8_snorm, r8_uint, r8_sint, r8_srgb,
 			// 16-bit (R8, G8)
@@ -221,9 +221,9 @@ DEFINE_ENUM(VFormat,
 			// 128-bit 4x4 BC7
 			bc7_rgba_unorm, bc7_rgba_srgb);
 
-VBaseFormat baseFormat(VFormat);
-VNumericFormat numericFormat(VFormat);
-Maybe<VFormat> makeFormat(VBaseFormat, VNumericFormat);
+VBaseFormat baseFormat(VColorFormat);
+VNumericFormat numericFormat(VColorFormat);
+Maybe<VColorFormat> makeFormat(VBaseFormat, VNumericFormat);
 
 DEFINE_ENUM(VFormatFeature, sampled_image, storage_image, storage_image_atomic,
 			uniform_texel_buffer, storage_texel_buffer, storage_texel_buffer_atomic, vertex_buffer,
@@ -236,18 +236,18 @@ struct VFormatSupport {
 	VFormatFeatures linear_tiling, optimal_tiling, buffer;
 };
 
-constexpr bool isBlock(VFormat format) {
-	return format >= VFormat::bc1_rgb_unorm && format <= VFormat::bc7_rgba_srgb;
+constexpr bool isBlock(VColorFormat format) {
+	return format >= VColorFormat::bc1_rgb_unorm && format <= VColorFormat::bc7_rgba_srgb;
 }
 
-int unitByteSize(VFormat);
-constexpr int unitSize(VFormat format) { return isBlock(format) ? 4 : 1; }
+int unitByteSize(VColorFormat);
+constexpr int unitSize(VColorFormat format) { return isBlock(format) ? 4 : 1; }
 
 // Formats which have same unit size & unit byte size are compatible.
-bool areCompatible(VFormat, VFormat);
+bool areCompatible(VColorFormat, VColorFormat);
 
-int2 imageBlockSize(VFormat format, int2 pixel_size);
-int imageByteSize(VFormat, int2 pixel_size);
+int2 imageBlockSize(VColorFormat format, int2 pixel_size);
+int imageByteSize(VColorFormat, int2 pixel_size);
 
 DEFINE_ENUM(VDepthStencilFormat, d16, d24_x8, d32f, s8, d16_s8, d24_s8, d32f_s8);
 
@@ -413,13 +413,13 @@ struct VDepthSync {
 };
 
 struct VColorAttachment {
-	VColorAttachment(VkFormat format, uint num_samples = 1, VColorSync sync = {})
+	VColorAttachment(VColorFormat format, uint num_samples = 1, VColorSync sync = {})
 		: format(format), num_samples(num_samples), sync(sync) {}
 
 	FWK_TIE_MEMBERS(format, num_samples, sync);
 	FWK_TIED_COMPARES(VColorAttachment);
 
-	VkFormat format;
+	VColorFormat format;
 	uint num_samples;
 	VColorSync sync;
 };

--- a/src/gfx/image.cpp
+++ b/src/gfx/image.cpp
@@ -22,36 +22,36 @@ namespace detail {
 	Ex<Image> loadSTBI(Stream &);
 }
 
-Image::Image(int2 size, VFormat format)
+Image::Image(int2 size, VColorFormat format)
 	: m_data(imageByteSize(format, size)), m_size(size), m_format(format) {
 	fwk::fill(m_data, 0);
 	DASSERT(size.x >= 0 && size.y >= 0);
 }
 
-Image::Image(int2 size, NoInitTag, VFormat format)
+Image::Image(int2 size, NoInitTag, VColorFormat format)
 	: m_data(imageByteSize(format, size)), m_size(size), m_format(format) {
 	DASSERT(size.x >= 0 && size.y >= 0);
 }
 
-Image::Image(int2 size, IColor color, VFormat format)
+Image::Image(int2 size, IColor color, VColorFormat format)
 	: m_data(imageByteSize(format, size)), m_size(size), m_format(format) {
 	DASSERT(size.x >= 0 && size.y >= 0);
 	fill(color);
 }
 
-Image::Image(PodVector<u8> data, int2 size, VFormat format)
+Image::Image(PodVector<u8> data, int2 size, VColorFormat format)
 	: m_data(std::move(data)), m_size(size), m_format(format) {
 	DASSERT(size.x >= 0 && size.y >= 0);
 	DASSERT(m_data.size() >= imageByteSize(format, m_size));
 }
 
-Image::Image(Image rhs, VFormat format)
+Image::Image(Image rhs, VColorFormat format)
 	: m_data(std::move(rhs.m_data)), m_size(rhs.m_size), m_format(format) {
 	rhs.m_size = int2(0, 0);
 	DASSERT(areCompatible(rhs.m_format, format));
 }
 
-Image::Image() : m_format(VFormat::rgba8_unorm) {}
+Image::Image() : m_format(VColorFormat::rgba8_unorm) {}
 Image::~Image() = default;
 
 using ImageLoaders = vector<Pair<string, Image::Loader>>;
@@ -96,7 +96,7 @@ Image::RegisterLoader::RegisterLoader(const char *ext, Loader func) {
 	loaders().emplace_back(ext, func);
 }
 
-Image Image::compressBC(const Image &image, VFormat format) {
+Image Image::compressBC(const Image &image, VColorFormat format) {
 	auto base_format = baseFormat(format);
 	auto numeric_format = numericFormat(format);
 
@@ -132,7 +132,7 @@ Image Image::compressBC(const Image &image, VFormat format) {
 	return {std::move(data), image.size(), format};
 }
 
-void Image::setFormat(VFormat new_format) {
+void Image::setFormat(VColorFormat new_format) {
 	DASSERT(areCompatible(m_format, new_format));
 	m_format = new_format;
 }

--- a/src/gfx/image_stbi.cpp
+++ b/src/gfx/image_stbi.cpp
@@ -38,7 +38,7 @@ namespace detail {
 			return sr.getValid().error();
 		}
 
-		Image out({w, h}, no_init, VFormat::rgba8_unorm);
+		Image out({w, h}, no_init, VColorFormat::rgba8_unorm);
 		// TODO: avoid copy
 		copy(out.data(), span(data, w * h * sizeof(IColor)));
 		stbi_image_free(data);

--- a/src/gfx/image_stbir.cpp
+++ b/src/gfx/image_stbir.cpp
@@ -33,7 +33,7 @@ Image Image::rescale(int2 new_size, ImageRescaleOpts opts) const {
 			alpha_opt, flags, STBIR_EDGE_CLAMP, STBIR_FILTER_DEFAULT, colorspace, nullptr);
 		if(!result)
 			FWK_FATAL("STB_image_resize failed!");
-	} else if(isOneOf(m_format, VFormat::rgb32_sfloat)) {
+	} else if(isOneOf(m_format, VColorFormat::rgb32_sfloat)) {
 		auto input_pixels = reinterpret_cast<const float *>(m_data.data());
 		auto output_pixels = reinterpret_cast<float *>(new_image.m_data.data());
 

--- a/src/gfx/investigator3.cpp
+++ b/src/gfx/investigator3.cpp
@@ -144,7 +144,7 @@ bool Investigator3::mainLoop() {
 
 	m_device->beginFrame().check();
 	auto sc_format = swap_chain->format();
-	auto depth_format = *m_depth_buffer->image()->depthStencilFormat();
+	auto depth_format = m_depth_buffer->image()->format().get<VDepthStencilFormat>();
 	auto render_pass_3d =
 		m_device->getRenderPass({{sc_format, 1, VColorSyncStd::clear}}, {depth_format});
 	auto render_pass_2d = m_device->getRenderPass({{sc_format, 1, VColorSyncStd::present}});

--- a/src/vulkan/vulkan_instance.cpp
+++ b/src/vulkan/vulkan_instance.cpp
@@ -388,7 +388,7 @@ static VFormatSupport formatSupport(VkPhysicalDevice phys_device, VkFormat forma
 						  fromVkFormatFeatures(props.formatProperties.bufferFeatures)};
 }
 
-VFormatSupport VulkanInstance::formatSupport(VPhysicalDeviceId phys_id, VFormat format) const {
+VFormatSupport VulkanInstance::formatSupport(VPhysicalDeviceId phys_id, VColorFormat format) const {
 	return fwk::formatSupport(m_phys_devices[phys_id].handle, toVk(format));
 }
 

--- a/src/vulkan/vulkan_pipeline.cpp
+++ b/src/vulkan/vulkan_pipeline.cpp
@@ -230,7 +230,7 @@ PVRenderPass VulkanRenderPass::create(VulkanDevice &device, CSpan<VColorAttachme
 		auto &src = colors[i];
 		auto &dst = attachments[i];
 		dst.flags = 0;
-		dst.format = src.format;
+		dst.format = toVk(src.format);
 		dst.samples = VkSampleCountFlagBits(src.num_samples);
 		dst.loadOp = toVk(src.sync.load_op);
 		dst.storeOp = toVk(src.sync.store_op);
@@ -392,7 +392,7 @@ Ex<PVPipeline> VulkanPipeline::create(VulkanDevice &device, VPipelineSetup setup
 	auto vertex_attribs = transform(setup.vertex_attribs, [](const VVertexAttrib &desc) {
 		VkVertexInputAttributeDescription out;
 		out.binding = desc.binding_index;
-		out.format = desc.format;
+		out.format = toVk(desc.format);
 		out.location = desc.location_index;
 		out.offset = desc.offset;
 		return out;

--- a/src/vulkan/vulkan_swap_chain.cpp
+++ b/src/vulkan/vulkan_swap_chain.cpp
@@ -109,7 +109,9 @@ Ex<void> VulkanSwapChain::initialize(const VSurfaceInfo &surf_info) {
 	}
 
 	// TODO: handle minimized extents
-	m_format = ci.imageFormat;
+	auto format = fromVkColorFormat(ci.imageFormat);
+	EXPECT(format && "Unrecognized swapchain color format");
+	m_format = *format;
 	m_size = int2(ci.imageExtent.width, ci.imageExtent.height);
 
 	FWK_VK_EXPECT_CALL(vkCreateSwapchainKHR, device, &ci, nullptr, &m_handle);
@@ -122,8 +124,7 @@ Ex<void> VulkanSwapChain::initialize(const VSurfaceInfo &surf_info) {
 
 	m_image_views.resize(num_images);
 	for(int i : intRange(num_images)) {
-		VImageSetup setup(ci.imageFormat, fromVk(ci.imageExtent), m_setup.usage,
-						  m_setup.initial_layout);
+		VImageSetup setup(m_format, fromVk(ci.imageExtent), m_setup.usage, m_setup.initial_layout);
 		auto image = VulkanImage::createExternal(device, images[i], setup);
 		m_image_views[i] = VulkanImageView::create(image);
 	}


### PR DESCRIPTION
- Renamed VFormat -> VColorFormat
- Using VFormatVariant in VulkanImage
- Using fwk types instead of VkFormat where feasible