### PR TITLE
Vulkan: Cleanup in RenderPass & Framebuffer creation

### DIFF
--- a/include/fwk/vulkan/vulkan_command_queue.h
+++ b/include/fwk/vulkan/vulkan_command_queue.h
@@ -105,6 +105,9 @@ class VulkanCommandQueue {
 	// TODO: pass colors & depth here directly
 	void beginRenderPass(PVFramebuffer, PVRenderPass, Maybe<IRect> render_area = none,
 						 CSpan<VClearValue> clear_values = {});
+	void beginRenderPass(CSpan<PVImageView> attachments, PVRenderPass,
+						 Maybe<IRect> render_area = none, CSpan<VClearValue> clear_values = {});
+
 	void endRenderPass();
 
 	void dispatchCompute(int3 size);

--- a/include/fwk/vulkan/vulkan_device.h
+++ b/include/fwk/vulkan/vulkan_device.h
@@ -55,8 +55,11 @@ class VulkanDevice {
 	// ----------  Object management  ------------------------------------------------------------
 
   public:
-	PVRenderPass getRenderPass(CSpan<VColorAttachment>, Maybe<VDepthAttachment> = none);
-	PVFramebuffer getFramebuffer(CSpan<PVImageView> colors, PVImageView depth = none);
+	PVRenderPass getRenderPass(CSpan<VAttachment>);
+	PVRenderPass getRenderPass(CSpan<PVImageView>, CSpan<VAttachmentSync>);
+	PVRenderPass getRenderPass(CSpan<PVImageView>, VSimpleSync);
+	PVFramebuffer getFramebuffer(CSpan<PVImageView>, PVRenderPass = none);
+
 	PVPipelineLayout getPipelineLayout(CSpan<VDSLId>, const VPushConstantRanges &);
 	PVPipelineLayout getPipelineLayout(CSpan<PVShaderModule>, const VPushConstantRanges &);
 	PVPipelineLayout getPipelineLayout(CSpan<PVShaderModule>);

--- a/include/fwk/vulkan/vulkan_framebuffer.h
+++ b/include/fwk/vulkan/vulkan_framebuffer.h
@@ -12,15 +12,17 @@ namespace fwk {
 
 class VulkanFramebuffer : public VulkanObjectBase<VulkanFramebuffer> {
   public:
-	static constexpr int max_color_atts = VulkanLimits::max_color_attachments;
+	static constexpr int max_colors = VulkanLimits::max_color_attachments;
+	static constexpr int max_attachments = max_colors + 1;
 
-	static PVFramebuffer create(PVRenderPass, CSpan<PVImageView> colors, PVImageView depth = none);
-	static u32 hashConfig(CSpan<PVImageView> colors, PVImageView depth);
+	static PVFramebuffer create(PVRenderPass, CSpan<PVImageView>);
+	static u32 hashConfig(CSpan<PVImageView>);
 
-	// TODO: somehow mark Ptrs that they are non-null?
-	CSpan<PVImageView> colors() const { return m_colors; }
-	PVImageView depth() const { return m_depth; }
-	bool hasDepth() const { return m_depth; }
+	PVRenderPass renderPass() const { return m_render_pass; }
+	CSpan<PVImageView> attachments() const { return m_attachments; }
+	CSpan<PVImageView> colors() const { return cspan(m_attachments.data(), m_num_colors); }
+	PVImageView depth() const { return m_has_depth ? m_attachments.back() : PVImageView(); }
+	bool hasDepth() const { return m_has_depth; }
 	int2 size() const { return m_size; }
 
   private:
@@ -28,8 +30,10 @@ class VulkanFramebuffer : public VulkanObjectBase<VulkanFramebuffer> {
 	VulkanFramebuffer(VkFramebuffer, VObjectId);
 	~VulkanFramebuffer();
 
-	StaticVector<PVImageView, max_color_atts> m_colors;
-	PVImageView m_depth;
+	StaticVector<PVImageView, max_attachments> m_attachments;
+	PVRenderPass m_render_pass;
 	int2 m_size;
+	int m_num_colors;
+	bool m_has_depth;
 };
 }

--- a/src/gfx/investigator2.cpp
+++ b/src/gfx/investigator2.cpp
@@ -171,13 +171,11 @@ bool Investigator2::mainLoop() {
 	applyFocus();
 
 	m_device->beginFrame().check();
-	auto swap_chain = m_device->swapChain();
-	auto render_pass =
-		m_device->getRenderPass({{swap_chain->format(), 1, VColorSyncStd::clear_present}});
-	auto frame_buffer = m_device->getFramebuffer({swap_chain->acquiredImage()});
+	auto screen = m_device->swapChain()->acquiredImage();
+	auto render_pass = m_device->getRenderPass({screen}, VSimpleSync::clear_present);
 
 	auto &cmds = m_device->cmdQueue();
-	cmds.beginRenderPass(frame_buffer, render_pass, none, {FColor(0.4, 0.5, 0.3)});
+	cmds.beginRenderPass({screen}, render_pass, none, {FColor(0.4, 0.5, 0.3)});
 	cmds.setViewport(m_viewport);
 	cmds.setScissor(none);
 	draw(render_pass);

--- a/src/gfx/investigator3.cpp
+++ b/src/gfx/investigator3.cpp
@@ -143,22 +143,20 @@ bool Investigator3::mainLoop() {
 	}
 
 	m_device->beginFrame().check();
-	auto sc_format = swap_chain->format();
+	auto screen = swap_chain->acquiredImage();
 	auto depth_format = m_depth_buffer->image()->format().get<VDepthStencilFormat>();
-	auto render_pass_3d =
-		m_device->getRenderPass({{sc_format, 1, VColorSyncStd::clear}}, {depth_format});
-	auto render_pass_2d = m_device->getRenderPass({{sc_format, 1, VColorSyncStd::present}});
-	auto frame_buffer = m_device->getFramebuffer({swap_chain->acquiredImage()}, m_depth_buffer);
+	auto render_pass_3d = m_device->getRenderPass({screen, m_depth_buffer}, VSimpleSync::clear);
+	auto render_pass_2d = m_device->getRenderPass({screen}, VSimpleSync::present);
 	auto &cmds = m_device->cmdQueue();
 
-	cmds.beginRenderPass(frame_buffer, render_pass_3d, none,
+	cmds.beginRenderPass({screen, m_depth_buffer}, render_pass_3d, none,
 						 {FColor(0.4, 0.5, 0.3), VClearDepthStencil(1.0)});
 	cmds.setViewport(viewport);
 	cmds.setScissor(none);
 	auto text = draw(render_pass_3d);
 	cmds.endRenderPass();
 
-	cmds.beginRenderPass(frame_buffer, render_pass_2d, none);
+	cmds.beginRenderPass({screen}, render_pass_2d, none);
 	FontStyle style{ColorId::white, ColorId::black};
 	auto extents = m_font->evalExtents(text);
 	Canvas2D canvas_2d(viewport, Orient2D::y_up);

--- a/src/tests/window.cpp
+++ b/src/tests/window.cpp
@@ -102,12 +102,12 @@ Ex<void> drawFrame(VulkanContext &ctx, CSpan<float2> positions, ZStr message) {
 	text += message;
 	ctx.font->draw(canvas, FRect({5, 5}, {200, 20}), {ColorId::white, ColorId::black}, text);
 
-	auto render_pass =
-		ctx.device->getRenderPass({{swap_chain->format(), 1, VColorSyncStd::clear_present}});
+	auto screen = swap_chain->acquiredImage();
+	auto render_pass = ctx.device->getRenderPass({screen}, VSimpleSync::clear_present);
+	auto framebuffer = ctx.device->getFramebuffer({screen});
 	auto dc = EX_PASS(canvas.genDrawCall(ctx.compiler, *ctx.device, render_pass));
-	auto fb = ctx.device->getFramebuffer({swap_chain->acquiredImage()});
 
-	cmds.beginRenderPass(fb, render_pass, none, {FColor(0.0, 0.2, 0.0)});
+	cmds.beginRenderPass(framebuffer, render_pass, none, {FColor(0.0, 0.2, 0.0)});
 	cmds.setViewport(IRect(swap_chain->size()));
 	cmds.setScissor(none);
 
@@ -269,7 +269,7 @@ Ex<int> exMain() {
 
 	// TODO: sc_format might change if we move to different screen
 	auto sc_format = ctx.device->swapChain()->format();
-	auto gui_rpass = ctx.device->getRenderPass({{sc_format, 1}});
+	auto gui_rpass = ctx.device->getRenderPass({{sc_format, VSimpleSync::draw}});
 	Gui gui(device, window, gui_rpass, GuiConfig{GuiStyleMode::mini});
 	ctx.gui = &gui;
 

--- a/src/tools/model_viewer.cpp
+++ b/src/tools/model_viewer.cpp
@@ -144,9 +144,7 @@ HashMap<string, PVImageView> loadImages(VulkanDevice &device, CSpan<Pair<string>
 
 PVRenderPass guiRenderPass(VDeviceRef device) {
 	auto sc_format = device->swapChain()->format();
-	auto color_sync = VColorSync(VLoadOp::load, VStoreOp::store, VImageLayout::general,
-								 VImageLayout::present_src);
-	return device->getRenderPass({{sc_format, 1, color_sync}});
+	return device->getRenderPass({{sc_format, VSimpleSync::draw}});
 }
 
 class Viewer {

--- a/src/vulkan/vulkan_command_queue.cpp
+++ b/src/vulkan/vulkan_command_queue.cpp
@@ -412,6 +412,13 @@ void VulkanCommandQueue::beginRenderPass(PVFramebuffer framebuffer, PVRenderPass
 	vkCmdBeginRenderPass(m_cur_cmd_buffer, &bi, VK_SUBPASS_CONTENTS_INLINE);
 }
 
+void VulkanCommandQueue::beginRenderPass(CSpan<PVImageView> attachments, PVRenderPass render_pass,
+										 Maybe<IRect> render_area,
+										 CSpan<VClearValue> clear_values) {
+	auto framebuffer = m_device.getFramebuffer(attachments, render_pass);
+	beginRenderPass(framebuffer, render_pass, render_area, clear_values);
+}
+
 void VulkanCommandQueue::endRenderPass() {
 	PASSERT(m_status == Status::frame_running);
 	vkCmdEndRenderPass(m_cur_cmd_buffer);

--- a/src/vulkan/vulkan_image.cpp
+++ b/src/vulkan/vulkan_image.cpp
@@ -72,7 +72,8 @@ Ex<PVImage> VulkanImage::create(VulkanDevice &device, const VImageSetup &setup,
 	ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 	ci.usage = toVk(setup.usage);
 
-	DASSERT(setup.dims.num_samples >= 1 && setup.dims.num_samples <= 64);
+	DASSERT(setup.dims.num_samples >= 1 &&
+			setup.dims.num_samples <= VulkanLimits::max_image_samples);
 	DASSERT(isPowerOfTwo(setup.dims.num_samples));
 	ci.samples = VkSampleCountFlagBits(setup.dims.num_samples);
 

--- a/todo.txt
+++ b/todo.txt
@@ -1,5 +1,7 @@
 TODO: prioritize aggresively
 
+- Move RenderPass to separate file
+- Option to mark Ptrs that they are non-null? New type like RVImageView?
 - Consider replacing mechanism for updating descriptors so that it won't require
   update_after_bind (does it affect performance?)
 - FilePath() should be empty; FilePath::empty() always returns false;


### PR DESCRIPTION
- Merged VColorSync & VDepthSync into VAttachmentSync
- Merged VColorAttachment & VDepthAttachment into VAttachment
- Framebuffers & RenderPasses are more convenient to use